### PR TITLE
Fixing data attributes output in helper tool

### DIFF
--- a/js/jquery.focuspoint.helpertool.js
+++ b/js/jquery.focuspoint.helpertool.js
@@ -101,7 +101,7 @@
 		/*-----------------------------------------*/
 		
 		function printDataAttr(){
-			$dataAttrInput.val('data-focus-x="'+focusPointAttr.x.toFixed(2)+'" data-focus-y="'+focusPointAttr.y.toFixed(2)+'" data-focus-w="'+focusPointAttr.w+'" data-focus-h="'+focusPointAttr.h+'"');
+			$dataAttrInput.val('data-focus-x="'+focusPointAttr.x.toFixed(2)+'" data-focus-y="'+focusPointAttr.y.toFixed(2)+'" data-image-w="'+focusPointAttr.w+'" data-image-h="'+focusPointAttr.h+'"');
 		}
 
 		/*-----------------------------------------*/


### PR DESCRIPTION
I noticed that the helper tool was outputting incorrect data attributes for width and height. 
- "focus-w" -> "image-w"
- "focus-h" -> "image-h"